### PR TITLE
Update Mesa options to be more similar to upstream Asahi

### DIFF
--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -6,11 +6,9 @@ runtime-version: '22.08'
 build-extension: true
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm14
-  - org.freedesktop.Sdk.Extension.rust-stable
 build-options:
   prepend-path: /usr/lib/sdk/llvm14/bin
   prepend-ld-library-path: /usr/lib/sdk/llvm14/lib
-  append-path: /usr/lib/sdk/rust-stable/bin
 cleanup:
   - /include
   - /lib/cmake
@@ -62,7 +60,7 @@ modules:
       - -Dvulkan-drivers=swrast,amd
       - -Ddri3=enabled
       - -Degl=enabled
-      - -Dgallium-rusticl=true
+      - -Dgallium-rusticl=false
       - -Dgallium-va=enabled
       - -Dgallium-vdpau=enabled
       - -Dgallium-xa=disabled

--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -60,7 +60,7 @@ modules:
       - -Dvulkan-drivers=swrast,amd
       - -Ddri3=enabled
       - -Degl=enabled
-      - -Dgallium-rusticl=enabled
+      - -Dgallium-rusticl=true
       - -Dgallium-va=enabled
       - -Dgallium-vdpau=enabled
       - -Dgallium-xa=disabled

--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -52,11 +52,21 @@ modules:
       prepend-pkg-config-path: /usr/lib/aarch64-linux-gnu/GL/asahi/lib/pkgconfig
     buildsystem: meson
     config-opts: &mesa-config-opts
-      - -Dgallium-drivers=asahi,swrast,virgl,zink
+      - -Dgallium-drivers=asahi,swrast,virgl,zink,kmsro
       - -Dzstd=enabled
       - -Dgbm=enabled
       - -Dplatforms=x11,wayland
       - -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec
+      - -Dvulkan-drivers=swrast,radv
+      - -Ddri3=enabled
+      - -Degl=enabled
+      - -Dgallium-rusticl=enabled
+      - -Dgallium-va=enabled
+      - -Dgallium-vdpau=enabled
+      - -Dgallium-xa=disabled
+      - -Dglx=dri
+      - -Dvalgrind=enabled
+      - -Dmicrosoft-clc=disabled
     sources:
       - type: archive
         url: https://gitlab.freedesktop.org/asahi/mesa/-/archive/01a8a3f3d6089d980e7ae56f6e631c8213f0e49d/mesa-01a8a3f3d6089d980e7ae56f6e631c8213f0e49d.tar.bz2

--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -10,6 +10,7 @@ sdk-extensions:
 build-options:
   prepend-path: /usr/lib/sdk/llvm14/bin
   prepend-ld-library-path: /usr/lib/sdk/llvm14/lib
+  append-path: /usr/lib/sdk/rust-stable/bin
 cleanup:
   - /include
   - /lib/cmake

--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -6,6 +6,7 @@ runtime-version: '22.08'
 build-extension: true
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm14
+  - org.freedesktop.Sdk.Extension.rust-stable
 build-options:
   prepend-path: /usr/lib/sdk/llvm14/bin
   prepend-ld-library-path: /usr/lib/sdk/llvm14/lib

--- a/org.freedesktop.Platform.GL.asahi.yml
+++ b/org.freedesktop.Platform.GL.asahi.yml
@@ -57,7 +57,7 @@ modules:
       - -Dgbm=enabled
       - -Dplatforms=x11,wayland
       - -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec
-      - -Dvulkan-drivers=swrast,radv
+      - -Dvulkan-drivers=swrast,amd
       - -Ddri3=enabled
       - -Degl=enabled
       - -Dgallium-rusticl=enabled


### PR DESCRIPTION
RADV is enabled as I don't have an M1 system, so I can only test using my x86 system.